### PR TITLE
Personalizacao do Card de Filme

### DIFF
--- a/back/db/database-usuarios.json
+++ b/back/db/database-usuarios.json
@@ -4,8 +4,51 @@
     "username": "joao_g_fs",
     "email": "juau@gmail.com",
     "senha": "$2b$10$mt677BBdwr.r.ADyPxM8qu9bDPd0..QjIlhyXG4OaVAHWKqfyVSpK",
-    "assistir": [],
-    "assistidos": []
+    "assistir": [
+      {
+        "id": 4233,
+        "poster_path": "/zqDrfOJ0ChhYFyv3iQyTgNZGs2B.jpg",
+        "release_date": "1997-12-12",
+        "title": "Pânico 2",
+        "overview": "Dois anos após o massacre em Woodsboro, Sidney Prescott e Randy Meeks estão tentando refazer suas vidas em uma nova cidade. Estudando no colégio de Windsor, eles vão lidar com uma nova onda de assassinatos quando o terrível psicopata retorna para assombrá-los nas vésperas do lançamento do filme baseado nos seus crimes."
+      },
+      {
+        "id": 1022789,
+        "poster_path": "/9h2KgGXSmWigNTn3kQdEFFngj9i.jpg",
+        "release_date": "2024-06-11",
+        "title": "Divertida Mente 2",
+        "overview": "\"Divertida Mente 2\", da Disney e da Pixar, retorna à mente da adolescente Riley, e o faz no momento em que a sala de comando está passando por uma demolição repentina para dar lugar a algo totalmente inesperado: novas emoções! Alegria, Tristeza, Raiva, Medo e Nojinho não sabem bem como reagir quando Ansiedade aparece, e tudo indica que ela não está sozinha."
+      }
+    ],
+    "assistidos": [
+      {
+        "id": 273248,
+        "poster_path": "/jfTo9U9OgOXODEEspNnYFuZdR1q.jpg",
+        "release_date": "2015-12-25",
+        "title": "Os Oito Odiados",
+        "overview": "Durante uma nevasca, um carrasco, uma prisioneira, um caçador de recompensas e um homem que alega ser xerife buscam abrigo no Armazém da Minnie, onde quatro outros desconhecidos estão abrigados. Aos poucos, os oito viajantes no local começam a descobrir os segredos sangrentos uns dos outros, levando a um inevitável confronto entre eles.",
+        "nota": "5",
+        "resenha": "Ótimo filme, com suspense e ótimos diálogos.\nAção bem feita e o final sangrento típico do Tarantino."
+      },
+      {
+        "id": 24,
+        "poster_path": "/v7TaX8kXMXs5yFFGR41guUDNcnB.jpg",
+        "release_date": "2003-10-10",
+        "title": "Kill Bill: Volume 1",
+        "overview": "A ex-assassina conhecida apenas como \"A Noiva\" acorda de um coma de quatro anos decidida a se vingar de Bill, seu ex-amante e chefe, que tentou matá-la no dia do casamento. Ela está motivada a acertar as contas com cada uma das pessoas envolvidas com a perda da filha, da festa de casamento e dos quatro anos da sua vida. Na jornada, \"A Noiva\" é submetida a dores físicas agoniantes ao enfrentar a inescrupulosa gangue de Bill, o Esquadrão Assassino de Víboras Mortais.",
+        "nota": "3",
+        "resenha": "Da hora"
+      },
+      {
+        "id": 64690,
+        "poster_path": "/602vevIURmpDfzbnv5Ubi6wIkQm.jpg",
+        "release_date": "2011-09-15",
+        "title": "Drive",
+        "overview": "Um motorista habilidoso é dublê em Hollywood e piloto de fuga em assaltos. Quando aceita ajudar o marido de sua vizinha Irene, fica na mira dos homens mais perigosos de LA. Mas o trabalho dá errado, e a única forma de garantir a segurança de Irene e do filho é fazer o que ele faz de melhor: dirigir.",
+        "nota": "3",
+        "resenha": "Eu draivo"
+      }
+    ]
   },
   {
     "id": 2,

--- a/front/src/componentes/CardFilme.jsx
+++ b/front/src/componentes/CardFilme.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom'
 import '../styles/CardFilme.css';
 
-export default function CardFilme({ poster_path, release_date, title, overview, id }) {
+export default function CardFilme({ poster_path, release_date, title, overview, id , botoes=['assistir', 'assistido'], resenha=''}) {
 
   const navigate = useNavigate();
 
@@ -15,7 +15,9 @@ export default function CardFilme({ poster_path, release_date, title, overview, 
     let lista = release_date.split('-');
     data = `${lista[2]}/${lista[1]}/${lista[0]}`;
   }
-  
+
+  let config = {headers: { Authorization: `Bearer ${sessionStorage.getItem('token')}`}}
+
   // Função para enviar solicitação "Quero assistir"
   const handleQueroAssistir = async () => {
     try {
@@ -25,12 +27,7 @@ export default function CardFilme({ poster_path, release_date, title, overview, 
         release_date,
         title,
         overview
-      }, 
-      {
-        headers: {
-          Authorization: `Bearer ${sessionStorage.getItem('token')}`
-        }
-      });
+      }, config);
       alert('Filme adicionado à lista "Quero assistir"');
     } catch (error) {
       alert('Erro ao adicionar filme à lista "Quero assistir"');
@@ -38,9 +35,42 @@ export default function CardFilme({ poster_path, release_date, title, overview, 
   };
 
   // Função para enviar solicitação "Já assisti"
-  const handleJaAssisti = async () => {
+  const handleJaAssisti = () => {
     navigate('/avaliar', {state: { poster_path, release_date, title, overview, id }});
   };
+
+  const editarAvaliacao = () => {
+    navigate('/avaliar', {state: { poster_path, release_date, title, overview, id }});
+  }
+
+  const handleDelete = async () => {
+    try{
+      const response = await axios.delete('http//localhost:3000/usuario/filme', {id}, config);
+    alert('Filme removido com sucesso!');
+    } catch (error) {
+      alert('Erro ao remover filme da lista!');
+    } 
+  }
+
+  let buttons = []
+  if(botoes.includes('assistir')){
+    buttons.push(<button id='btn-assistir' onClick={handleQueroAssistir}>Quero assistir</button>);
+  }
+  if(botoes.includes('assistido')){
+    buttons.push(<button id='btn-assistido' onClick={handleJaAssisti}>Já assisti</button>)
+  }
+  if(botoes.includes('editar')){
+    buttons.push(<button id='btn-assistido' onClick={editarAvaliacao}>Editar</button>)
+  }
+  if(botoes.includes('remover')){
+    buttons.push(<button id='btn-remover' onClick={handleDelete}>Remover</button>)
+  }
+  
+  let cardText
+  if(resenha === '')
+    cardText = overview
+  else
+    cardText = resenha
 
   return (
     <div id='card-filme'>
@@ -49,13 +79,12 @@ export default function CardFilme({ poster_path, release_date, title, overview, 
             <div id='card-head'>
                 <h2>{title}</h2>
                 <div id='buttons'>
-                    <button onClick={handleQueroAssistir}>Quero assistir</button>
-                    <button onClick={handleJaAssisti}>Já assisti</button>
+                    {buttons}
                 </div>
             </div>
             <div id='card-text'>
                 <p>Data de lançamento: {data}</p>
-                <p id='descricao-filme'>{overview}</p>
+                <p id='descricao-filme'>{cardText}</p>
             </div>
         </div>
     </div>

--- a/front/src/componentes/TelaAssistidos.jsx
+++ b/front/src/componentes/TelaAssistidos.jsx
@@ -35,7 +35,7 @@ export default function TelaAssistidos() {
     <section>
         <ul>
             {watched.map(filme => <li>
-                <CardFilme key={filme.id} {...filme}/>
+                <CardFilme key={filme.id} {...filme} botoes={['editar', 'remover']}/>
             </li>)}
         </ul>
     </section>

--- a/front/src/componentes/TelaAssistir.jsx
+++ b/front/src/componentes/TelaAssistir.jsx
@@ -35,7 +35,7 @@ export default function TelaAssistir() {
     <section>
         <ul>
             {watch.map(filme => <li>
-                <CardFilme key={filme.id} {...filme}/>
+                <CardFilme key={filme.id} {...filme} botoes={['assistido', 'remover']}/>
             </li>)}
         </ul>
     </section>

--- a/front/src/styles/Avaliacao.css
+++ b/front/src/styles/Avaliacao.css
@@ -8,7 +8,7 @@
     align-items: flex-start;
 }
 
-h2 {
+#avaliacao h2 {
     font-size: 2.5em;
     margin: 5px;
 }

--- a/front/src/styles/CardFilme.css
+++ b/front/src/styles/CardFilme.css
@@ -31,3 +31,16 @@ img{
     justify-content: space-between;
     padding-top: 30px;
 }
+
+#btn-remover {
+    background-color: rgb(228, 35, 9);
+}
+
+#btn-assistir{
+    background-color:  rgb(65, 65, 161);
+}
+
+#btn-assistido{
+    background-color: rgb(255, 187, 0);
+    color: black;
+}


### PR DESCRIPTION
# Personalizacao do Card de Filme

### Personalização dos botoes
Ao usar o card filme, é possível passar, através da propriedade `botoes` na chamada de HTML do `CardFilme`, quais botões devem ser incluidos na tela. A propriedade deve receber uma lista com as opções.
As opções padrão são `assistir`, `assistidos`, mas existem também `editar` e `remover`. 

### Personalização do texto do card
Para que fosse possível substituir o overview do filme pela resenha, foi criada a variável `cardText`. Se o  `CardFilme` receber um objeto que tenha a propriedade resenha com string não-vazia, o texto do card será a resenha. Senão, será preenchida pela overview recebida pela API.